### PR TITLE
Add notebook with examples of namedtuples vs dataclasses

### DIFF
--- a/classes/namedtuples-vs-dataclasses.ipynb
+++ b/classes/namedtuples-vs-dataclasses.ipynb
@@ -1,0 +1,567 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Named Tuples vs Data Classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from collections import namedtuple\n",
+    "from typing import Any, NamedTuple, OrderedDict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A named tuple can be defined either by using the `collections.namedtuple` function or defining a subclass inheriting from `typing.NamedTuple`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Grade: NamedTuple = namedtuple('Grade', ('score', 'weight'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Grade(score=99, weight=0.1)"
+      ]
+     },
+     "execution_count": 174,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade = Grade(99, 0.10)\n",
+    "grade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GradeNt(NamedTuple):\n",
+    "    \"\"\"Represents a grade, inheriting from NamedTuple.\"\"\"\n",
+    "    score: int\n",
+    "    weight: float\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GradeNt(score=99, weight=0.1)"
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt = GradeNt(99, 0.10)\n",
+    "grade_nt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Grade(score=99, weight=0.1), GradeNt(score=99, weight=0.1))"
+      ]
+     },
+     "execution_count": 177,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade, grade_nt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both objects have the same value and size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade == grade_nt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(72, 72)"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sys.getsizeof(grade), sys.getsizeof(grade_nt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, using a class has the added benefit of enabling type annotations and default values. Also a real docstring. One could possibly argue that the code is more readable and explicit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GradeNtDefault(NamedTuple):\n",
+    "    \"\"\"Represents a grade, inheriting from NamedTuple.\"\"\"\n",
+    "    score: int\n",
+    "    weight: float\n",
+    "    comment: str = 'Good job from NamedTuple class'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GradeNtDefault(score=99, weight=0.1, comment='Good job from NamedTuple class')"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt1 = GradeNtDefault(99, 0.10)\n",
+    "grade_nt1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In both cases values are still accesible via named attributes and numerical index:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(99, 99)"
+      ]
+     },
+     "execution_count": 182,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade.score, grade_nt1.score,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(99, 99)"
+      ]
+     },
+     "execution_count": 183,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade[0], grade_nt1[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To prevent access via numerical index, we can override the dunder (double underscore) `__getitem__` method and throw a `TypeError` whenever we try to access a value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GradeNtGi(NamedTuple):\n",
+    "    \"\"\"Represents a grade, inheriting from NamedTuple.\"\"\"\n",
+    "    score: int\n",
+    "    weight: float\n",
+    "    comment: str = 'Good job from NamedTuple class with overridden __getitem__'\n",
+    "\n",
+    "    def __getitem__(self, value):\n",
+    "        \"\"\"Prevent accessing value via numerical index.\"\"\"\n",
+    "        raise TypeError(f\"'Grade' is not subscriptable by index\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GradeNtGi(score=99, weight=0.1, comment='Good job from NamedTuple class with overridden __getitem__')"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt2 = GradeNtGi(99, 0.10)\n",
+    "grade_nt2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grade_nt2[0]  # Throws TypeError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This works as expected when we try to use a numerical index, but it also throws a `TypeError` when we use named attributes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grade_nt2.score  # Throws TypeError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To allow acces with named attributes we need to override another special method: `__getattribute__`. Named tuples do not have access to the `__dict__` attribute, but by using `_asdict()` we can get a value using the attribute name as key. The attribute name is passed to `__getattribute__` as an argument `name`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 188,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Applications/miniconda3/lib/python3.7/site-packages/ipykernel_launcher.py:1: DeprecationWarning: __class__ not set defining 'GradeGiGa' as <class '__main__.GradeGiGa'>. Was __classcell__ propagated to type.__new__?\n",
+      "  \"\"\"Entry point for launching an IPython kernel.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class GradeGiGa(NamedTuple):\n",
+    "    \"\"\"Represents a grade, inheriting from NamedTuple.\"\"\"\n",
+    "    score: int\n",
+    "    weight: float\n",
+    "    comment: str = 'Good job from NamedTuple class with overridden __getitem__ and __getattribute__'\n",
+    "\n",
+    "    def __getattribute__(self, name: str):\n",
+    "        \"\"\"Enable getting values with named attributes.\n",
+    "        \n",
+    "        Note that namedtuple has no attribute __dict__, _asdict() method is used instead.\n",
+    "        \"\"\"\n",
+    "        try:\n",
+    "            return super().__getattribute__(name)\n",
+    "        except TypeError:\n",
+    "            class_dict: OrderedDict[str, Any] = self._asdict()  # No __dict__ attribute for namedtuple\n",
+    "            return class_dict[name]\n",
+    "\n",
+    "    def __getitem__(self, value):\n",
+    "        \"\"\"Prevent accessing value via numerical index to avoid unintentional use in external APIs.\"\"\"\n",
+    "        raise TypeError(f\"'Grade' is not subscriptable by index\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 189,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GradeGiGa(score=99, weight=0.1, comment='Good job from NamedTuple class with overridden __getitem__ and __getattribute__')"
+      ]
+     },
+     "execution_count": 189,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt3 = GradeGiGa(99, 0.10)\n",
+    "grade_nt3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can access values with named attributes but not with numerical index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(99, 0.1)"
+      ]
+     },
+     "execution_count": 190,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt3.score, grade_nt3.weight"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grade_nt3[0], grade_nt3[1]  # Throws TypeError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This works but is not an ideal solution. Since Python **3.7** there is the [`dataclass` module](https://www.python.org/dev/peps/pep-0557/). Dataclasses seem to be able to replace named tuples in most cases if not all. They too do not require a defined `__init__` method and are declared in a very similar way to a class inheriting from `NamedTuple`. The class is decorated with the `@dataclass` decorator, and to make the objects \"immutable\", the `frozen` keyword can be set to `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "\n",
+    "@dataclass(frozen=True)  # Try commenting out the decorator\n",
+    "class GradeDc:  # Inherits from object\n",
+    "    \"\"\"Represents a grade.\"\"\"\n",
+    "    score: int\n",
+    "    weight: float\n",
+    "    comment: str = 'Good job from dataclass!'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GradeDc(score=99, weight=0.1, comment='Good job from dataclass!')"
+      ]
+     },
+     "execution_count": 193,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_dc = GradeDc(99, 0.10)\n",
+    "grade_dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dataclasses already has the desired behaviour of only allowing named attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(99, 0.1)"
+      ]
+     },
+     "execution_count": 194,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_dc.score, grade_dc.weight"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grade_dc[0], grade_dc[1]  # Throws TypeError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 196,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(GradeGiGa(score=99, weight=0.1, comment='Good job from NamedTuple class with overridden __getitem__ and __getattribute__'),\n",
+       " GradeDc(score=99, weight=0.1, comment='Good job from dataclass!'))"
+      ]
+     },
+     "execution_count": 196,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grade_nt3, grade_dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dataclasses are somewhat more lightweight than named tuples but the main benefit is that we don't have to override any dunder methods to get the desired behaviour, and a dataclass describes more accurately what we want to achieve: a lightweight class that is easy to declare and instantiate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 197,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(72, 72, 80, 64)"
+      ]
+     },
+     "execution_count": 197,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sys.getsizeof(grade), sys.getsizeof(grade_nt), sys.getsizeof(grade_nt1), sys.getsizeof(grade_dc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I've written a notebook with some comparisons between the different ways to create a `namedtuple` and how they compare to creating and using a `dataclass`. The latter seems to be the superior alternative and it may be that the book is outdated on this topic.
I am not sure of the terminology and would really appreciate if someone took a look through to possibly make it more consistent/correct.